### PR TITLE
Use uniform with hint_screen_texture instead of SCREEN_TEXTURE

### DIFF
--- a/addons/panku_console/res/shader/distort.gdshader
+++ b/addons/panku_console/res/shader/distort.gdshader
@@ -5,10 +5,11 @@ uniform float distort:hint_range(0.0, 0.1) = 0.01;
 uniform float scale:hint_range(0.1, 100.0) = 20.0;
 uniform float blur:hint_range(1.0, 5.0) = 1.9;
 uniform float darken:hint_range(0.0, 1.0) = 0.0;
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_linear_mipmap;
 
 void fragment() {
 	vec4 col1 = texture(tex1, SCREEN_UV * scale);
 	vec2 uv = SCREEN_UV + col1.xz * distort;
-	vec4 col2 = textureLod(SCREEN_TEXTURE, uv, blur);
+	vec4 col2 = textureLod(screen_texture, uv, blur);
 	COLOR = mix(col2, vec4(0.0, 0.0, 0.0, 1.0), darken);
 }

--- a/addons/panku_console/res/shader/frosted_glass.gdshader
+++ b/addons/panku_console/res/shader/frosted_glass.gdshader
@@ -4,9 +4,10 @@ uniform float amount: hint_range(0.0, 5.0);
 uniform float noise: hint_range(0.0, 1.0);
 uniform float sz: hint_range(0.0, 0.5);
 uniform float fancy: hint_range(0.0, 1.0) = 0.0;
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_linear_mipmap;
 
 void fragment() {
-	vec3 col1 = textureLod(SCREEN_TEXTURE, SCREEN_UV, amount).rgb;
+	vec3 col1 = textureLod(screen_texture, SCREEN_UV, amount).rgb;
 	vec3 col2 = vec3((sin(UV.x + TIME*1.0) + 1.0)/2.0, (sin(UV.y+TIME*1.5))/2.0,(sin(UV.x * UV.y + TIME*2.0)+1.0)/2.0);
 	float m = step(fract((sz / SCREEN_PIXEL_SIZE.x)*SCREEN_UV.x), 0.5) * step(fract((sz / SCREEN_PIXEL_SIZE.y)*SCREEN_UV.y), 0.5);
 	col1 = col1 * (m * noise + (1.0 - noise));

--- a/addons/panku_console/res/shader/simple_fast_blur.gdshader
+++ b/addons/panku_console/res/shader/simple_fast_blur.gdshader
@@ -1,8 +1,9 @@
 shader_type canvas_item;
 
 uniform float lod:hint_range(0.0, 5.0) = 0.0;
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_linear_mipmap;
 
 void fragment() {
-	vec3 col = textureLod(SCREEN_TEXTURE, SCREEN_UV, lod).rgb;
+	vec3 col = textureLod(screen_texture, SCREEN_UV, lod).rgb;
 	COLOR = vec4(col, 1.0);
 }


### PR DESCRIPTION
Godot 4 Beta 14 has removed `SCREEN_TEXTURE` in favor of using uniforms with hints (see this for more details: https://github.com/godotengine/godot/pull/70967).

This PR updates the shaders to use the new method of accessing the screen texture.