### PR TITLE
Fix problem of setting menu

### DIFF
--- a/addons/panku_console/components/exporter/exporter_2.gd
+++ b/addons/panku_console/components/exporter/exporter_2.gd
@@ -50,7 +50,7 @@ func setup(_obj:Object):
 	#get all export properties from its script
 	var data = script.get_script_property_list()
 	var row = null
-	var group:Array = []
+	var group:Array[Control] = []
 	var group_buttons = []
 	var last_group_button = null
 	for d in data:


### PR DESCRIPTION
When click setting menu, there is an error that can't assign `Array` to `Array[Control]`

![image](https://user-images.githubusercontent.com/88229072/217703451-7908a74d-752e-4410-9270-8db113dcb96e.png)

![image](https://user-images.githubusercontent.com/88229072/217703414-514c6795-9bb8-47ed-9959-a6c7c7954935.png)

So I modify `local var group` 's type to `Array[Control]`, then problem is solved.