### PR TITLE
Do not modify project.godot unnecessarily

### DIFF
--- a/addons/panku_console/console.gd
+++ b/addons/panku_console/console.gd
@@ -22,6 +22,13 @@ func notify(any) -> void:
 	var text = str(any)
 	new_notification_created.emit(text)
 
+func _init():
+	if not InputMap.has_action("toggle_console"):
+		InputMap.add_action("toggle_console")
+		var default_open_console_event = InputEventKey.new()
+		default_open_console_event.physical_keycode = KEY_QUOTELEFT
+		InputMap.action_add_event("toggle_console", default_open_console_event)
+
 func _input(_e):
 	# change this to your own action, by default it is `toggle_console`(KEY_QUOTELEFT)
 	if Input.is_action_just_pressed("toggle_console"):

--- a/addons/panku_console/plugin.gd
+++ b/addons/panku_console/plugin.gd
@@ -9,16 +9,10 @@ const SingletonName = "Panku"
 func _enter_tree():
 	# Initialization of the plugin goes here.
 	add_autoload_singleton(SingletonName, "res://addons/panku_console/console.tscn")
-	var default_open_console_event = InputEventKey.new()
-	default_open_console_event.physical_keycode = KEY_QUOTELEFT
-	ProjectSettings.set_setting("input/toggle_console", {"deadzone":0.5,"events":[default_open_console_event]})
-	ProjectSettings.save()
 	print("Panku Console was initialized!")
 	print("Project page: https://github.com/Ark2000/PankuConsole")
 
 func _exit_tree():
 	# Clean-up of the plugin goes here.
 	remove_autoload_singleton(SingletonName)
-	ProjectSettings.clear("input/toggle_console")
-	ProjectSettings.save()
 	print("Panku Console was unloaded!")


### PR DESCRIPTION
The current implementation has annoying behavior. It would constantly write content to `project.godot` when the project was opened, and delete them after exiting; this created a lot of mess in the VCS history. This PR solves that problem without changing other behavior.