### PR TITLE
Prevent console toggling input from being interpreted twice

### DIFF
--- a/addons/panku_console/console.gd
+++ b/addons/panku_console/console.gd
@@ -23,8 +23,8 @@ func notify(any) -> void:
 	var text = str(any)
 	new_notification_created.emit(text)
 
-func _input(e):
-	if Input.is_action_just_pressed(ToggleConsoleAction):
+func _input(event: InputEvent):
+	if event.is_action(ToggleConsoleAction) and Input.is_action_just_pressed(ToggleConsoleAction):
 		toggle_console_action_just_pressed.emit()
 
 func _ready():


### PR DESCRIPTION
This is required since for each frame, `_input` might run several times (if you have several input events, such as moving the mouse and clicking it at the same time). As a result, just checking the global state with `Input.is_action_just_pressed` will return `true` for both events and will show and hide the console in the same frame. (see https://github.com/godotengine/godot/issues/80158#issuecomment-1661865675)

(to check that it's a problem, you can move the mouse continually and try toggling the console: you'll notice it sometimes doesn't show up)