### PR TITLE
Autoave options

### DIFF
--- a/addons/panku_console/common/lynx_window2/lynx_windows_manager_2.gd
+++ b/addons/panku_console/common/lynx_window2/lynx_windows_manager_2.gd
@@ -2,7 +2,7 @@
 class_name PankuLynxWindowsManager extends Control
 
 const CFG_ENABLE_OS_WINDOW = "enable_os_window"
-const CFG_OS_WINDOW_BGCOLOR = "os_window_bgcolor"
+const CFG_OS_WINDOW_BGCOLOR = "os_window_bg_color"
 
 @onready var console:PankuConsole = get_node(PankuConsole.SingletonPath)
 

--- a/addons/panku_console/common/module_options.gd
+++ b/addons/panku_console/common/module_options.gd
@@ -2,15 +2,9 @@ class_name ModuleOptions extends Resource
 
 var _module:PankuModule
 
-signal update_setting(key: String, value: Variant)
+var _loaded := false
 
-var loaded := false:
-	set(l):
-		if l:
-			update_setting.connect(_module.save_module_data)
-		else:
-			if update_setting.is_connected(_module.save_module_data):
-				update_setting.disconnect(_module.save_module_data)
-	get:
-		return update_setting.is_connected(_module.save_module_data)
-
+func update_setting(key: String, value: Variant):
+	self.set(key, value)
+	if _loaded and _module:
+		_module.save_module_data(key, value)

--- a/addons/panku_console/common/module_options.gd
+++ b/addons/panku_console/common/module_options.gd
@@ -1,0 +1,16 @@
+class_name ModuleOptions extends Resource
+
+var _module:PankuModule
+
+signal update_setting(key: String, value: Variant)
+
+var loaded := false:
+	set(l):
+		if l:
+			update_setting.connect(_module.save_module_data)
+		else:
+			if update_setting.is_connected(_module.save_module_data):
+				update_setting.disconnect(_module.save_module_data)
+	get:
+		return update_setting.is_connected(_module.save_module_data)
+

--- a/addons/panku_console/common/panku_module.gd
+++ b/addons/panku_console/common/panku_module.gd
@@ -16,7 +16,7 @@ func init_module():
 # called when the module is unloaded (quit program)
 func quit_module():
 	if _opt:
-		_opt.loaded = false
+		_opt._loaded = false
 
 # called at the start of each physics frame
 func update_module(delta:float):
@@ -75,4 +75,4 @@ func _init_module():
 
 	init_module()
 	if _opt:
-		_opt.loaded = true
+		_opt._loaded = true

--- a/addons/panku_console/common/panku_module.gd
+++ b/addons/panku_console/common/panku_module.gd
@@ -3,7 +3,7 @@ class_name PankuModule
 var core:PankuConsole
 
 var _env:RefCounted = null
-var _opt:Resource = null
+var _opt:ModuleOptions = null
 
 # dir name of the module
 func get_module_name() -> String:
@@ -15,7 +15,8 @@ func init_module():
 
 # called when the module is unloaded (quit program)
 func quit_module():
-	pass
+	if _opt:
+		_opt.loaded = false
 
 # called at the start of each physics frame
 func update_module(delta:float):
@@ -54,7 +55,7 @@ func save_window_data(window:PankuLynxWindow):
 func get_module_env() -> RefCounted:
 	return _env
 
-func get_module_opt() -> Resource:
+func get_module_opt() -> ModuleOptions:
 	return _opt
 
 func _init_module():
@@ -69,7 +70,9 @@ func _init_module():
 
 	if FileAccess.file_exists(opt_script_path):
 		#print(opt_script_path)
-		_opt = load(opt_script_path).new()
+		_opt = load(opt_script_path).new() as ModuleOptions
 		_opt._module = self
 
 	init_module()
+	if _opt:
+		_opt.loaded = true

--- a/addons/panku_console/modules/check_latest_release/opt.gd
+++ b/addons/panku_console/modules/check_latest_release/opt.gd
@@ -1,5 +1,4 @@
-extends Resource
-var _module:PankuModule
+extends ModuleOptions
 
 @export_group("check_latest_release")
 

--- a/addons/panku_console/modules/data_controller/exporter/exporter_2.gd
+++ b/addons/panku_console/modules/data_controller/exporter/exporter_2.gd
@@ -132,7 +132,10 @@ func init_data():
 				if !is_instance_valid(obj):
 					return
 				if prop_name in obj:
-					obj.set(prop_name, val)
+					if obj.has_method("update_setting"):
+						obj.update_setting(prop_name, val)
+					else:
+						obj.set(prop_name, val)
 		)
 
 func init_ui_row(ui_row:Control, property:Dictionary) -> Control:

--- a/addons/panku_console/modules/engine_tools/opt.gd
+++ b/addons/panku_console/modules/engine_tools/opt.gd
@@ -1,5 +1,4 @@
-extends Resource
-var _module:PankuModule
+extends ModuleOptions
 
 @export_group("engine_tools")
 

--- a/addons/panku_console/modules/general_settings/module.gd
+++ b/addons/panku_console/modules/general_settings/module.gd
@@ -8,15 +8,8 @@ func open_settings_window():
 
 func init_module():
 	# load settings
-	get_module_opt().window_blur_effect = load_module_data("lynx_window_blur_effect", true)
-	get_module_opt().window_color = load_module_data("lynx_window_base_color", Color("#000c1880"))
-	get_module_opt().enable_os_window = load_module_data("lynx_window_enable_os_window", false)
-	get_module_opt().os_window_bg_color = load_module_data("lynx_window_os_window_bg_color", Color(0, 0, 0, 0))
+	get_module_opt().window_blur_effect = load_module_data("window_blur_effect", true)
+	get_module_opt().window_base_color = load_module_data("window_base_color", Color("#000c1880"))
+	get_module_opt().enable_os_window = load_module_data("enable_os_window", false)
+	get_module_opt().os_window_bg_color = load_module_data("os_window_bg_color", Color(0, 0, 0, 0))
 
-func quit_module():
-	# save settings
-	save_module_data("lynx_window_blur_effect", get_module_opt().window_blur_effect)
-	save_module_data("lynx_window_base_color", get_module_opt().window_color)
-	save_module_data("lynx_window_enable_os_window", get_module_opt().enable_os_window)
-	save_module_data("lynx_window_os_window_bg_color", get_module_opt().os_window_bg_color)
-	

--- a/addons/panku_console/modules/general_settings/opt.gd
+++ b/addons/panku_console/modules/general_settings/opt.gd
@@ -8,7 +8,7 @@ extends ModuleOptions
 	get:
 		return PankuLynxWindow.lynx_window_shader_material.get("shader_parameter/lod") > 0.0
 
-@export var window_color:Color = Color(0.0, 0.0, 0.0, 0.1):
+@export var window_base_color:Color = Color(0.0, 0.0, 0.0, 0.1):
 	set(v):
 		PankuLynxWindow.lynx_window_shader_material.set("shader_parameter/modulate", v)
 	get:

--- a/addons/panku_console/modules/general_settings/opt.gd
+++ b/addons/panku_console/modules/general_settings/opt.gd
@@ -1,8 +1,6 @@
-extends Resource
+extends ModuleOptions
 
-var _module:PankuModule
-
-@export_group("common_settings")
+@export_group("general_settings")
 
 @export var window_blur_effect:bool = true:
 	set(v):

--- a/addons/panku_console/modules/history_manager/opt.gd
+++ b/addons/panku_console/modules/history_manager/opt.gd
@@ -1,6 +1,4 @@
-extends Resource
-
-var _module:PankuModule
+extends ModuleOptions
 
 @export_group("history_manager")
 

--- a/addons/panku_console/modules/interactive_shell/opt.gd
+++ b/addons/panku_console/modules/interactive_shell/opt.gd
@@ -1,6 +1,4 @@
-extends Resource
-
-var _module:PankuModule
+extends ModuleOptions
 
 @export_group("interactive_shell")
 

--- a/addons/panku_console/modules/keyboard_shortcuts/exp_key_mapper_2.gd
+++ b/addons/panku_console/modules/keyboard_shortcuts/exp_key_mapper_2.gd
@@ -1,5 +1,8 @@
 extends Control
 
+signal key_binding_added(key: InputEventKey, expression: String)
+signal key_binding_changed(key: InputEventKey, expression: String)
+
 var console:PankuConsole
 
 const exp_key_item := preload("./exp_key_item.tscn")
@@ -10,7 +13,6 @@ const exp_key_item := preload("./exp_key_item.tscn")
 var mapping_data = []
 
 func _ready():
-
 	#when clicking the button, add a new exp key mapping item
 	add_btn.pressed.connect(
 		func():
@@ -48,10 +50,14 @@ func add_item(exp:String, event:InputEventKey):
 	item.exp_edit_submitted.connect(
 		func(new_exp:String):
 			mapping_data[item.get_index()][0] = new_exp
+			if(key_binding_added.get_connections().size() > 0):
+				key_binding_added.emit(event, new_exp)
 	)
 	item.remap_button.key_event_changed.connect(
 		func(new_event:InputEventKey):
 			mapping_data[item.get_index()][1] = new_event
+			if(key_binding_changed.get_connections().size() > 0):
+				key_binding_changed.emit(new_event, mapping_data[item.get_index()][0])
 	)
 	item.tree_exiting.connect(
 		func():

--- a/addons/panku_console/modules/keyboard_shortcuts/module.gd
+++ b/addons/panku_console/modules/keyboard_shortcuts/module.gd
@@ -15,6 +15,14 @@ func init_module():
 
 	load_window_data(window)
 	key_mapper.load_data(load_module_data("key_mapper", []))
+	key_mapper.key_binding_added.connect(
+		func(key: InputEventKey, expression: String):
+			save_module_data("key_mapper", key_mapper.get_data())
+	)
+	key_mapper.key_binding_changed.connect(
+		func(key: InputEventKey, expression: String):
+			save_module_data("key_mapper", key_mapper.get_data())
+	)
 
 func quit_module():
 	save_window_data(window)

--- a/addons/panku_console/modules/keyboard_shortcuts/opt.gd
+++ b/addons/panku_console/modules/keyboard_shortcuts/opt.gd
@@ -1,5 +1,4 @@
-extends Resource
-var _module:PankuModule
+extends ModuleOptions
 
 @export_group("keyboard_shortcuts")
 

--- a/addons/panku_console/modules/native_logger/module.gd
+++ b/addons/panku_console/modules/native_logger/module.gd
@@ -53,13 +53,9 @@ func init_module():
 
 
 func quit_module():
+	super.quit_module()
 	save_window_data(window)
-	save_module_data("font_size", get_module_opt().font_size)
-	save_module_data("screen_overlay", get_module_opt().screen_overlay)
-	save_module_data("screen_overlay_alpha", get_module_opt().screen_overlay_alpha)
-	save_module_data("screen_overlay_font_size", get_module_opt().screen_overlay_font_size)
 	save_module_data("screen_overlay_font_shadow", get_module_opt().screen_overlay_font_shadow)
-	save_module_data("font_size", get_module_opt().font_size)
 	save_module_data("logger_tags", logger_ui.get_data())
 
 func open_window():

--- a/addons/panku_console/modules/native_logger/opt.gd
+++ b/addons/panku_console/modules/native_logger/opt.gd
@@ -21,16 +21,19 @@ func open_window():
 		_module.output_overlay.visible = v
 	get:
 		return _module.output_overlay.visible
+
 @export_range(0.0, 1.0, 0.01) var screen_overlay_alpha:float = 0.5:
 	set(v):
 		_module.output_overlay.modulate.a = v
 	get:
 		return _module.output_overlay.modulate.a
+
 @export_range(8, 24) var screen_overlay_font_size:int = 16:
 	set(v):
 		_module.output_overlay.theme.default_font_size = v
 	get:
 		return _module.output_overlay.theme.default_font_size
+
 @export var screen_overlay_font_shadow:bool = false:
 	set(v):
 		var val = Color.BLACK if v else null

--- a/addons/panku_console/modules/native_logger/opt.gd
+++ b/addons/panku_console/modules/native_logger/opt.gd
@@ -1,5 +1,4 @@
-extends Resource
-var _module:PankuModule
+extends ModuleOptions
 
 @export_group("native_logger")
 

--- a/addons/panku_console/modules/screen_crt_effect/opt.gd
+++ b/addons/panku_console/modules/screen_crt_effect/opt.gd
@@ -1,6 +1,4 @@
-extends Resource
-
-var _module:PankuModule
+extends ModuleOptions
 
 @export_group("screen_crt_effect")
 


### PR DESCRIPTION
Automatically save panku_config.cfg as soon as an option is changed or a key mapping is changed, make settings key names more consistent with their labels, related to #121 