### PR TITLE
Auto save main windows geometry on close

### DIFF
--- a/addons/panku_console/common/panku_module.gd
+++ b/addons/panku_console/common/panku_module.gd
@@ -59,9 +59,21 @@ func load_window_data(window:PankuLynxWindow):
 	window.set_window_visibility(load_module_data("window_visibility", false))
 
 func save_window_data(window:PankuLynxWindow):
+	_save_window_geometry(window)
+	save_module_data("window_visibility", window.visible)
+
+
+func _save_window_geometry(window:PankuLynxWindow):
 	save_module_data("window_position", window.position)
 	save_module_data("window_size", window.get_normal_window_size())
-	save_module_data("window_visibility", window.visible)
+
+
+# Add hook to window to auto save its geometry on close.
+func add_auto_save_hook(window: PankuLynxWindow) -> void:
+	# Here some global settings check can be implemented,
+	# if we decide to make "save on close" feature optional
+	window.window_closed.connect(_save_window_geometry.bind(window))
+
 
 func get_module_env() -> RefCounted:
 	return _env
@@ -73,7 +85,7 @@ func _init_module():
 	var module_script_dir:String = get_script().resource_path.get_base_dir()
 	var env_script_path = module_script_dir + "/env.gd"
 	var opt_script_path = module_script_dir + "/opt.gd"
-	
+
 	if FileAccess.file_exists(env_script_path):
 		_env = load(env_script_path).new()
 		_env._module = self

--- a/addons/panku_console/modules/expression_monitor/module.gd
+++ b/addons/panku_console/modules/expression_monitor/module.gd
@@ -21,6 +21,7 @@ func init_monitor_window():
 	monitor._module = self
 #	monitor.set_data(load_module_data("exprs", []))
 	monitor_window = core.windows_manager.create_window(monitor)
+	add_auto_save_hook(monitor_window)
 	monitor_window.queue_free_on_close = false
 	monitor_window.set_window_title_text("Expression Monitor")
 

--- a/addons/panku_console/modules/history_manager/module.gd
+++ b/addons/panku_console/modules/history_manager/module.gd
@@ -13,6 +13,7 @@ func init_module():
 
 	# bind window
 	window = core.windows_manager.create_window(ui)
+	add_auto_save_hook(window)
 	window.queue_free_on_close = false
 	window.set_window_title_text("History Manager")
 	load_window_data(window)

--- a/addons/panku_console/modules/interactive_shell/module.gd
+++ b/addons/panku_console/modules/interactive_shell/module.gd
@@ -27,6 +27,7 @@ func get_intro() -> String:
 func init_module():
 	interactive_shell = preload("./console_ui/panku_console_ui.tscn").instantiate()
 	window = core.windows_manager.create_window(interactive_shell)
+	add_auto_save_hook(window)
 	interactive_shell._repl._module = self
 	window.queue_free_on_close = false
 	window.set_window_title_text("Interative Shell V2")
@@ -68,7 +69,7 @@ func init_module():
 	pause_if_input = load_module_data("pause_if_popup", true)
 	unified_window_visibility = load_module_data("unified_visibility", false)
 	init_expr = load_module_data("init_expression", "")
-	
+
 	_show_side_menu = load_module_data("show_side_menu", true)
 	set_side_menu_visible(_show_side_menu)
 
@@ -84,7 +85,7 @@ func init_module():
 				var result = core.gd_exprenv.execute(init_expr)
 				core.new_expression_entered.emit(init_expr, result)
 		).set_delay(0.1)
-	
+
 	_input_histories = load_module_data("histories", [])
 
 func quit_module():

--- a/addons/panku_console/modules/keyboard_shortcuts/module.gd
+++ b/addons/panku_console/modules/keyboard_shortcuts/module.gd
@@ -10,6 +10,7 @@ func init_module():
 
 	# bind window
 	window = core.windows_manager.create_window(key_mapper)
+	add_auto_save_hook(window)
 	window.queue_free_on_close = false
 	window.set_window_title_text("Keyboard Shortcuts")
 

--- a/addons/panku_console/modules/native_logger/module.gd
+++ b/addons/panku_console/modules/native_logger/module.gd
@@ -28,6 +28,7 @@ func init_module():
 	logger_ui.console = core
 
 	window = core.windows_manager.create_window(logger_ui)
+	add_auto_save_hook(window)
 	window.queue_free_on_close = false
 	window.set_window_title_text("Native Logger")
 
@@ -47,7 +48,7 @@ func init_module():
 		func(bbcode:String):
 			output_overlay.text = bbcode
 	)
-	
+
 	core.interactive_shell_visibility_changed.connect(
 		func(v:bool):
 			if output_overlay_display_mode == ScreenOverlayDisplayMode.ShowIfShellVisible:


### PR DESCRIPTION
Panku saves its windows placement on `NOTIFICATION_WM_CLOSE_REQUEST`, but it doesn't not work in editor (F8). This PR offers auto save window geometry on window close, which will make windows management a bit more convenient.