### PR TITLE
More tricks for current scene detection

### DIFF
--- a/addons/panku_console/modules/variable_tracker/opt.gd
+++ b/addons/panku_console/modules/variable_tracker/opt.gd
@@ -6,13 +6,24 @@ extends ModuleOptions
 	"Use last non singleton node as current scene. "
 	+ "First node will be used if this option disabled."
 )
-
 @export var use_last_as_current: bool:
 	get:
 		return _module._reverse_root_nodes_order
-	set(v):
-		use_last_as_current = v
-		_module._reverse_root_nodes_order = v
+	set(value):
+		use_last_as_current = value
+		_module._reverse_root_nodes_order = value
+
+@export var export_comment_root_node_exceptions = (
+	"Top level nodes which will be ignored by variable tracker. "
+	+ "Regular expressions can be used e.g. '(SignalBus|Game*)'."
+)
+@export var root_node_exceptions: String:
+	get:
+		return _module._raw_exceptions_string
+	set(value):
+		root_node_exceptions = value
+		_module._raw_exceptions_string = value
+		_module.update_exceptions_regexp()
 
 @export var export_comment_tracking_delay = "Current scene checking interval."
 @export_range(0.1, 2.0, 0.1) var tracking_delay := 0.5:

--- a/addons/panku_console/modules/variable_tracker/opt.gd
+++ b/addons/panku_console/modules/variable_tracker/opt.gd
@@ -2,6 +2,17 @@ extends ModuleOptions
 
 @export_group("variable_tracker")
 
+@export var export_comment_use_last_as_current = (
+	"Use last non singleton node as current scene. "
+	+ "First node will be used if this option disabled."
+)
+
+@export var use_last_as_current: bool:
+	get:
+		return _module._reverse_root_nodes_order
+	set(v):
+		use_last_as_current = v
+		_module._reverse_root_nodes_order = v
 
 @export var export_comment_tracking_delay = "Current scene checking interval."
 @export_range(0.1, 2.0, 0.1) var tracking_delay := 0.5:


### PR DESCRIPTION
This PR addressing #171 problem. Since current scene detection algorithm kinda weak, I propose few extra settings in variable tracker module to control it. 

* Setting to use last top level node as current scene instead of first one. This solution was mentioned in related issue, but lets make it optional just in case.
* Setting to which allows to manually configure exceptions, top level nodes straight up ignored by variable tracker. This also allows to avoid flooding console namespace in project with many singletons.