### PR TITLE
feat: custom default config file

### DIFF
--- a/addons/panku_console/common/config.gd
+++ b/addons/panku_console/common/config.gd
@@ -1,25 +1,36 @@
 class_name PankuConfig
 
-const FILE_NAME = "panku_config.cfg"
-const FILE_PATH = "user://" + FILE_NAME
+const USER_CONFIG_FILE_PATH = "user://panku_config.cfg"
 
-static func set_config(config:Dictionary):
-	var file = FileAccess.open(FILE_PATH, FileAccess.WRITE)
-	var content = var_to_str(config)
-	file.store_string(content)
-
-static func get_config() -> Dictionary:
-	if FileAccess.file_exists(FILE_PATH):
-		var file = FileAccess.open(FILE_PATH, FileAccess.READ)
-		var content = file.get_as_text()
+# load config from file, always return a dictionary
+static func _get_config(file_path:String) -> Dictionary:
+	if FileAccess.file_exists(file_path):
+		var file = FileAccess.open(file_path, FileAccess.READ)
+		var content := file.get_as_text()
 		var config:Dictionary = str_to_var(content)
 		if config: return config
 	return {}
 
+# save user config to file
+static func set_config(config:Dictionary):
+	var file = FileAccess.open(USER_CONFIG_FILE_PATH, FileAccess.WRITE)
+	var content = var_to_str(config)
+	file.store_string(content)
+
+# get config, if user config exists, return user config, otherwise return default config configured by plugin user
+static func get_config() -> Dictionary:
+	var user_config:Dictionary = _get_config(USER_CONFIG_FILE_PATH)
+	if not user_config.is_empty():
+		return user_config
+	# if no user config, return default config, which is read-only
+	var default_config:Dictionary = _get_config(PankuConsolePlugin.get_custom_default_config_path())
+	print(PankuConsolePlugin.get_custom_default_config_path())
+	return default_config
+
 static func get_value(key:String, default:Variant) -> Variant:
 	return get_config().get(key, default)
-	
+
 static func set_value(key:String, val:Variant) -> void:
-	var config = get_config()
+	var config = _get_config(USER_CONFIG_FILE_PATH)
 	config[key] = val
 	set_config(config)

--- a/addons/panku_console/common/config.gd
+++ b/addons/panku_console/common/config.gd
@@ -23,9 +23,10 @@ static func get_config() -> Dictionary:
 	if not user_config.is_empty():
 		return user_config
 	# if no user config, return default config, which is read-only
-	var default_config:Dictionary = _get_config(PankuConsolePlugin.get_custom_default_config_path())
-	print(PankuConsolePlugin.get_custom_default_config_path())
-	return default_config
+	if PankuConsolePlugin.is_custom_default_config_exists():
+		return _get_config(PankuConsolePlugin.get_custom_default_config_path())
+		
+	return _get_config(PankuConsolePlugin.INITIAL_DEFAULT_CONFIG_FILE_PATH)
 
 static func get_value(key:String, default:Variant) -> Variant:
 	return get_config().get(key, default)

--- a/addons/panku_console/default_panku_config.cfg
+++ b/addons/panku_console/default_panku_config.cfg
@@ -1,0 +1,80 @@
+{
+"enable_os_window": false,
+"engine_tools": {
+"time_scale": 1.0
+},
+"exp_history": [],
+"expression_monitor": {
+"monitor_data": [{
+"expressions": ["engine_tools.get_performance_info()"],
+"group_name": "default group"
+}],
+"window_position": Vector2(0, 49),
+"window_size": Vector2(85, 74),
+"window_visibility": false
+},
+"general_settings": {
+"enable_os_window": false,
+"lynx_window_base_color": Color(0, 0.0470588, 0.0941176, 0.501961),
+"lynx_window_blur_effect": true,
+"lynx_window_enable_os_window": false,
+"lynx_window_os_window_bg_color": Color(0, 0, 0, 0.658824),
+"os_window_bg_color": Color(0, 0, 0, 0.992157),
+"window_blur_effect": true,
+"window_position": Vector2(429.546, 94.1911),
+"window_size": Vector2(512.568, 478.128),
+"window_visibility": true
+},
+"history_manager": {
+"window_position": Vector2(317.728, 138.82),
+"window_size": Vector2(411.987, 339.537),
+"window_visibility": false
+},
+"interactive_shell": {
+"gui_mode": 0,
+"histories": [],
+"init_expr": "",
+"output_font_size": 14.0,
+"pause_if_input": false,
+"pause_if_popup": false,
+"show_side_menu": true,
+"unified_visibility": false,
+"unified_window_visibility": false,
+"window_position": Vector2(427.419, 75.3913),
+"window_size": Vector2(510.736, 410.437),
+"window_visibility": true
+},
+"keyboard_shortcuts": {
+"key_mapper": [],
+"window_position": Vector2(0, 49),
+"window_size": Vector2(85, 74),
+"window_visibility": false
+},
+"native_logger": {
+"font_size": 17.0,
+"logger_tags": ["[error]", "[warning]", "[info]"],
+"screen_overlay": 0,
+"screen_overlay_alpha": 0.44,
+"screen_overlay_font_shadow": true,
+"screen_overlay_font_size": 20.0,
+"show_timestamp": true,
+"window_position": Vector2(284.123, 124.547),
+"window_size": Vector2(483.998, 379.028),
+"window_visibility": false
+},
+"os_window_bg_color": Color(0, 0, 0, 0.992157),
+"os_window_bgcolor": Color(0, 0, 0, 0.658824),
+"snake": {
+"leader_board": [{
+"score": 40,
+"timestamp": "2024-01-29T16:00:00"
+}, {
+"score": 20,
+"timestamp": "2024-01-29T16:01:14"
+}]
+},
+"variable_tracker": {
+"tracking_delay": 0.5,
+"use_last_as_current": true
+}
+}

--- a/addons/panku_console/plugin.gd
+++ b/addons/panku_console/plugin.gd
@@ -1,17 +1,21 @@
 @tool
+class_name PankuConsolePlugin
 extends EditorPlugin
 
 const SINGLETON_NAME = "Panku"
 const SINGLETON_PATH = "res://addons/panku_console/console.tscn"
 const SINGLETON_OPTION = "autoload/" + SINGLETON_NAME
+const INITIAL_DEFAULT_CONFIG_FILE_PATH = "res://addons/panku_console/default_panku_config.cfg"
 
 const CONFIG_SECTION = "panku"
 const OPTIONS = {
-	DISABLE_ON_RELEASE = 'disable_on_release'
+	# See https://github.com/Ark2000/PankuConsole/issues/170
+	DISABLE_ON_RELEASE = 'disable_on_release',
+	# See https://github.com/Ark2000/PankuConsole/issues/173
+	CUSTOM_DEFAULT_CONFIG = 'custom_default_config',
 }
 
 var exporter: PankuExporter
-
 
 # Custom export plugin to automatically disable console in release builds
 class PankuExporter extends EditorExportPlugin:
@@ -39,11 +43,32 @@ class PankuExporter extends EditorExportPlugin:
 		if need_restore_singleton:
 			owner.safe_add_singleton()
 
+# A helper function to add custom project settings
+# See https://dfaction.net/handling-custom-project-settings-using-gdscript/
+static func add_custom_project_setting(name: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE, hint_string: String = "") -> void:
+	if ProjectSettings.has_setting(name): return
+
+	var setting_info: Dictionary = {
+		"name": name,
+		"type": type,
+		"hint": hint,
+		"hint_string": hint_string
+	}
+
+	ProjectSettings.set_setting(name, default_value)
+	ProjectSettings.add_property_info(setting_info)
+	ProjectSettings.set_initial_value(name, default_value)
+	ProjectSettings.set_as_basic(name, true)
 
 # Full option name in project settings.
-func panku_option(option: String) -> String:
+static func panku_option(option: String) -> String:
 	return CONFIG_SECTION + "/" + option
 
+static func get_custom_default_config_path() -> String:
+	return ProjectSettings.get_setting(panku_option(OPTIONS.CUSTOM_DEFAULT_CONFIG), INITIAL_DEFAULT_CONFIG_FILE_PATH)
+
+static func is_custom_default_config_exists() -> bool:
+	return FileAccess.file_exists(get_custom_default_config_path())
 
 # Adding singleton with preliminary check to avoid any conflicts.
 func safe_add_singleton() -> void:
@@ -56,23 +81,40 @@ func safe_remove_singleton() -> void:
 	if ProjectSettings.has_setting(SINGLETON_OPTION):
 		remove_autoload_singleton(SINGLETON_NAME)
 
-
 func create_setting() -> void:
-	if not ProjectSettings.has_setting(panku_option(OPTIONS.DISABLE_ON_RELEASE)):
-		ProjectSettings.set_setting(panku_option(OPTIONS.DISABLE_ON_RELEASE), false)
-		ProjectSettings.set_initial_value(panku_option(OPTIONS.DISABLE_ON_RELEASE), false)
-		ProjectSettings.save()
+	# Seems we can't add descriptions to custom settings now.
 
+	# Disable Panku Console in release builds
+	add_custom_project_setting(
+		panku_option(OPTIONS.DISABLE_ON_RELEASE), 
+		false, 
+		TYPE_BOOL
+	)
+	# Path to the custom `res://` path default config file, useful if you are going to keep panku console in release builds.
+	add_custom_project_setting(
+		panku_option(OPTIONS.CUSTOM_DEFAULT_CONFIG), 
+		INITIAL_DEFAULT_CONFIG_FILE_PATH, 
+		TYPE_STRING, 
+		PROPERTY_HINT_FILE,
+		"*.cfg"
+	)
+
+	var error:int = ProjectSettings.save()
+	if error != OK:
+		push_error("Encountered error %d when saving project settings." % error)
 
 func _enter_tree() -> void:
-	exporter = PankuExporter.new()
+	# See https://github.com/godotengine/godot/issues/73525
+	exporter = (PankuExporter as Variant).new()
 	exporter.owner = self
 	add_export_plugin(exporter)
 	create_setting()
 
 	safe_add_singleton()
-	print("Panku Console initialized! Project page: https://github.com/Ark2000/PankuConsole")
+	print("[Panku Console] initialized! Project page: https://github.com/Ark2000/PankuConsole")
 
+	if not is_custom_default_config_exists():
+		push_warning("[Panku Console] Default config file not found. Using code-level default config.")
 
 func _exit_tree() -> void:
 	remove_export_plugin(exporter)
@@ -87,4 +129,4 @@ func _disable_plugin() -> void:
 			ProjectSettings.clear(opt)
 	ProjectSettings.save()
 
-	print("Panku Console disabled.")
+	print("[Panku Console] disabled.")


### PR DESCRIPTION
closes https://github.com/Ark2000/PankuConsole/issues/173

**Expected Behavior:**

1. `user://panku_config.cfg` file exists, that is used as the config dictionary
2. If the user config file does not exist (for example, for first-time users), then use `res://addons/panku_console/panku_default_config.cfg` (which can be changed in project settings) as the config dictionary.
3. The plugin will always get a config dictionary, whether the config files exist or not.
4. If there's no corresponding key-value pair in the config dictionary, the default value in the function call will be used.

**Note:**
The user config file (which is located at `user://`) will always be created after the program starts, the default config file (located at `res://`) is in fact simply a read-only and for one use only template file.