### PR TITLE
Fix type checks in data controller module

### DIFF
--- a/addons/panku_console/modules/data_controller/exporter/row_ui.gd
+++ b/addons/panku_console/modules/data_controller/exporter/row_ui.gd
@@ -5,7 +5,7 @@ var name_label:Label:
 
 signal ui_val_changed(val)
 
-func get_ui_val():
+func get_ui_val() -> Variant:
 	return null
 
 func update_ui(val):


### PR DESCRIPTION
Have errors after updating to Godot 4.3, probably they improve type checks on inheritance. 
```
  Failed parse script res://addons/panku_console/modules/data_controller/exporter/row_ui_color.gd
  The function signature doesn't match the parent. Parent signature is "get_ui_val() -> Variant".
  Failed parse script res://addons/panku_console/modules/data_controller/exporter/row_ui_string.gd
  The function signature doesn't match the parent. Parent signature is "get_ui_val() -> Variant".
  Failed parse script res://addons/panku_console/modules/data_controller/exporter/row_ui_bool.gd
  The function signature doesn't match the parent. Parent signature is "get_ui_val() -> Variant".
```
This minor tweak resolve the issue.
