### PR TITLE
fix: timescale 0.993

### DIFF
--- a/addons/panku_console/modules/engine_tools/opt.gd
+++ b/addons/panku_console/modules/engine_tools/opt.gd
@@ -27,11 +27,11 @@ func toggle_2d_debug_draw():
 func reload_current_scene():
 	_module.reload_current_scene()
 
-@export_range(0.1, 2.0) var time_scale := 1.0:
+@export_range(0.1, 10.0, 0.01) var time_scale := 1.0:
 	set(v):
 		time_scale = v
 		_module.set_time_scale(time_scale)
 
 @export var readonly_performance_info:String:
 	get:
-		return _module.get_performance_info()
+		return _module.get_performance_info(false)


### PR DESCRIPTION
problem:
* can not set timescale to 1.0, you will always get 0.993
* also, the plugin will crash due to #191, argument missing.