### PR TITLE
Add option to show node count

### DIFF
--- a/addons/panku_console/modules/engine_tools/module.gd
+++ b/addons/panku_console/modules/engine_tools/module.gd
@@ -1,5 +1,9 @@
 class_name PankuModuleEngineTools extends PankuModule
 
+func init_module():
+	get_module_opt().count_nodes = load_module_data("count_nodes", false)
+	super.init_module()
+
 func toggle_fullscreen() -> void:
 	if DisplayServer.window_get_mode() != DisplayServer.WINDOW_MODE_WINDOWED:
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)

--- a/addons/panku_console/modules/engine_tools/opt.gd
+++ b/addons/panku_console/modules/engine_tools/opt.gd
@@ -32,6 +32,9 @@ func reload_current_scene():
 		time_scale = v
 		_module.set_time_scale(time_scale)
 
+@export var export_comment_count_nodes = "Show node count in performance info (can issue extra performance hit)."
+@export var count_nodes := false
+
 @export var readonly_performance_info:String:
 	get:
-		return _module.get_performance_info(false)
+		return _module.get_performance_info(count_nodes)


### PR DESCRIPTION
Add option to show node count in engine tools module performance info. The mechanic itself was implemented in #191, this PR just expose user option as mentioned in #196.