### PR TITLE
fix: issue with end_idx inferring int type from variant type

### DIFF
--- a/addons/panku_console/modules/history_manager/exp_history.gd
+++ b/addons/panku_console/modules/history_manager/exp_history.gd
@@ -89,7 +89,7 @@ func reload():
 	
 	#remove existing list items
 	var start_idx := (current_page - 1) * items_per_page
-	var end_idx := min(start_idx + items_per_page, item_data.size())
+	var end_idx := mini(start_idx + items_per_page, item_data.size())
 	for c in item_container.get_children():
 		c.queue_free()
 	


### PR DESCRIPTION
var types cannot be inferred using := from variant types so I used `mini` instead of `min` to correctly return an int type