### PR TITLE
Use resource loader for script existence check

### DIFF
--- a/addons/panku_console/common/panku_module.gd
+++ b/addons/panku_console/common/panku_module.gd
@@ -86,12 +86,12 @@ func _init_module():
 	var env_script_path = module_script_dir + "/env.gd"
 	var opt_script_path = module_script_dir + "/opt.gd"
 
-	if FileAccess.file_exists(env_script_path):
+	if ResourceLoader.exists(env_script_path, "GDScript"):
 		_env = load(env_script_path).new()
 		_env._module = self
 		core.gd_exprenv.register_env(get_module_name(), _env)
 
-	if FileAccess.file_exists(opt_script_path):
+	if ResourceLoader.exists(opt_script_path, "GDScript"):
 		#print(opt_script_path)
 		_opt = load(opt_script_path).new() as ModuleOptions
 		_opt._module = self

--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ config/description="**Panku Console is a feature-packed real-time debugging tool
 
 Panku Console is designed to be modular and extensible, and it is easy to add and maintain features. It is also designed to be as unobtrusive as possible, so you can use it in your project without worrying about the impact on the final product."
 run/main_scene="res://example/main.tscn"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.3", "Forward Plus")
 boot_splash/bg_color=Color(1, 1, 1, 1)
 boot_splash/image="res://example/assets/bootsplash.png"
 boot_splash/fullsize=false


### PR DESCRIPTION
Latest versions of Godot can produce bytecode `gdc` files on export, so script existence check with `FileAccess` is not so reliable. `ResourceLoader` should manage the problem.

Resolves #209.